### PR TITLE
Update to Ubuntu Trusty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,17 @@
 # Tinyproxy (https://banu.com/tinyproxy/)
 
-FROM ubuntu:precise
+FROM ubuntu:trusty
 MAINTAINER Ryan Seto <ryanseto@yak.net>
 
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list && \
-        apt-get update && \
-        apt-get upgrade
+RUN     apt-get update && \
+        apt-get -y upgrade && \
+        apt-get -y install tinyproxy && \
+        rm -rf /var/lib/apt/lists/*
 
 # Ensure UTF-8
 RUN locale-gen en_US.UTF-8
 ENV LANG       en_US.UTF-8
 ENV LC_ALL     en_US.UTF-8
-
-# Prevent apt-get from complaining with: Unable to connect to Upstart
-RUN dpkg-divert --local --rename --add /sbin/initctl && \
-        ln -s /bin/true /sbin/initctl
-
-# Install Tinyproxy
-RUN apt-get -y install tinyproxy
-
-# Configure Tinyproxy
-# This allows allows all connections.
-RUN sed -i -e"s/^Allow /#Allow /" /etc/tinyproxy.conf
 
 USER nobody
 EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ RUN locale-gen en_US.UTF-8
 ENV LANG       en_US.UTF-8
 ENV LC_ALL     en_US.UTF-8
 
+# Configure Tinyproxy
+# This allows allows all connections.
+RUN sed -i -e"s/^Allow /#Allow /" /etc/tinyproxy.conf
+
 USER nobody
 EXPOSE 8888
 ENTRYPOINT ["/usr/sbin/tinyproxy", "-d"]


### PR DESCRIPTION
Changes:
- Updated image to Ubuntu 14.04 LTS (Trusty)
- Removed unneccessary moving for `/sbin/initctl` as the bug became fixed in 14.04
- Removing package lists to keep the image size small
